### PR TITLE
22 New Auth Middleware

### DIFF
--- a/lib/zerigodns.rb
+++ b/lib/zerigodns.rb
@@ -8,6 +8,7 @@ require 'zerigodns/client/response_code'
 require 'zerigodns/middleware'
 require 'zerigodns/middleware/xml'
 require 'zerigodns/middleware/error_handler'
+require 'zerigodns/middleware/zerigo_auth'
 
 require 'zerigodns/resource'
 require 'zerigodns/resource/rest'

--- a/lib/zerigodns/client.rb
+++ b/lib/zerigodns/client.rb
@@ -46,7 +46,7 @@ module ZerigoDNS
         @connection ||= Faraday.new(
           url: ZerigoDNS.config.site, 
         ) do |faraday|
-          faraday.request :basic_auth, ZerigoDNS.config.user, ZerigoDNS.config.api_key
+          faraday.request :zerigo_auth
           faraday.request :multipart
           faraday.request :url_encoded
           

--- a/lib/zerigodns/middleware/zerigo_auth.rb
+++ b/lib/zerigodns/middleware/zerigo_auth.rb
@@ -1,0 +1,26 @@
+# Handles authentication using the Zerigo config.
+class ZerigoDNS::Middleware::ZerigoAuth < Faraday::Middleware
+  # Constructs new middleware instance
+  def initialize app=nil, options={}
+    @app = app
+  end
+  
+  # Adds username & api key to Basic Auth header.
+  # @param [Faraday::Request] env The request
+  def call env
+    # => Ruby 1.8.7 does not support Base64.strict_encode64
+    auth_enc = Base64.encode64(formatted_login).gsub("\n", '')
+    env.request_headers['Authorization'] = "Basic #{auth_enc}"
+    @app.call(env)
+  end
+  
+  private
+  
+  # Gets the user:password format from ZerigoDNS.config
+  # @return [String] formatted login details
+  def formatted_login
+    [ZerigoDNS.config.user, ZerigoDNS.config.api_key].join(':')
+  end
+end
+
+Faraday::Request.register_middleware zerigo_auth: ZerigoDNS::Middleware::ZerigoAuth

--- a/spec/units/middleware/zerigo_auth_spec.rb
+++ b/spec/units/middleware/zerigo_auth_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe ZerigoDNS::Middleware::ZerigoAuth do
+  describe '#call' do
+    before :each do
+      
+      ZerigoDNS.config.user = 'user'
+      ZerigoDNS.config.api_key = 'pass'
+      
+      @client = Faraday.new do |builder|
+        builder.request :zerigo_auth
+        
+        builder.adapter :test do |stub|
+          stub.get('/test') {|env| [200, {'Content-Type' => 'text/xml'}, '<data>123</data>']}
+        end
+      end
+    end
+    
+    
+    let(:correct_auth) {'Basic dXNlcjpwYXNz'}
+    
+    
+    it 'adds the correct header' do
+      response = @client.get('/test')
+      expect(response.env.request_headers['Authorization']).to eq correct_auth
+    end
+  end
+end


### PR DESCRIPTION
Ref #22 

Added middleware which reads the `user` & `api_key` from the `ZerigoDNS.config` every time it is executed.  This allows for the configuration to be changed by the user after the client has been instantiated.

